### PR TITLE
[CI] Fix PyPI publishing configuration in GitHub Actions

### DIFF
--- a/.github/workflows/test-and-publish.yaml
+++ b/.github/workflows/test-and-publish.yaml
@@ -103,6 +103,7 @@ jobs:
 
           [publish.repo.main]
           url = 'https://upload.pypi.org/legacy/'
+          user = '__token__'
           auth = '${{ secrets.PYPI_API_TOKEN }}'
           " > ~/.config/hatch/config.toml
 


### PR DESCRIPTION
⚡ *Have you read the [Contributing Guidelines](./CONTRIBUTING.md)?*

Fixes #

## Description

Improve the PyPI publishing process by configuring Hatch credentials directly in the workflow, avoiding keyring dependency issues in CI environment. This change:

 - Fix the error: "Missing required option: user"

The configuration now uses a direct auth token approach which is more suitable for CI/CD environments while maintaining security best practices.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would break existing functionality)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [x] CI/CD related changes
- [ ] Other (please describe):

## Checklist

- [x] I have followed the project's coding style guidelines
- [ ] I have added tests that prove my fix/feature works
- [x] All existing tests pass locally
- [ ] I have updated the documentation accordingly
- [ ] I have added appropriate type hints
- [x] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings or errors
- [x] I have checked my code with `black`, `isort`, and `mypy`