### PR TITLE
[CI] Update PyPI publishing workflow to use trusted publishing

### DIFF
--- a/.github/workflows/test-and-publish.yaml
+++ b/.github/workflows/test-and-publish.yaml
@@ -78,6 +78,11 @@ jobs:
     name: Publish to PyPI
     needs: [ test, code-quality ]
     runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/bcra-connector
+    permissions:
+      id-token: write
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
 
     steps:
@@ -96,9 +101,8 @@ jobs:
       - name: Build package
         run: hatch build
 
-      - name: Publish to PyPI
-        env:
-          HATCH_INDEX_REPO: main
-          HATCH_INDEX_USER: __token__
-          HATCH_INDEX_AUTH: ${{ secrets.PYPI_API_TOKEN }}
-        run: hatch publish
+      - name: Test package
+        run: hatch run test
+
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
⚡ Enhance PyPI Publishing with Trusted Publishing

*Have you read the [Contributing Guidelines](https://github.com/PPeitsch/bcra-connector/blob/main/.github/CONTRIBUTING.md)?*

## Description
Replace manual PyPI publishing with official PyPA action using trusted publishing for enhanced security. This change improves our CI/CD pipeline by implementing a more secure and standardized approach to package publishing while maintaining consistency with our existing build tools.

The implementation keeps using hatch for build processes to maintain consistency with our project tooling, but leverages PyPA's official action for the actual publishing step, which provides enhanced security through trusted publishing.

Main changes:
- Add PyPI environment configuration with trusted publishing
- Configure necessary GitHub permissions for secure publishing
- Add package testing step before publishing
- Update PyPI project URL configuration
- Maintain hatch for build consistency

## Type of Change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would break existing functionality)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [x] CI/CD related changes
- [ ] Other (please describe):

## Checklist
- [x] I have followed the project's coding style guidelines
- [x] I have added tests that prove my fix/feature works
- [x] All existing tests pass locally
- [x] I have updated the documentation accordingly
- [x] I have added appropriate type hints
- [x] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings or errors
- [x] I have checked my code with `black`, `isort`, and `mypy`