### PR TITLE
[CI] Remove redundant dev dependencies installation

### DIFF
--- a/.github/workflows/test-and-publish.yaml
+++ b/.github/workflows/test-and-publish.yaml
@@ -97,6 +97,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install hatch
+          pip install .[dev]
 
       - name: Build package
         run: hatch build


### PR DESCRIPTION
The dev dependencies are not needed in publish job since we only require build and pytest packages.

Changes made:
 - Remove pip install .[dev] line as it's redundant
 - Keep only essential dependencies for publishing"

⚡ ⚡ *Have you read the [Contributing Guidelines](https://github.com/PPeitsch/bcra-connector/blob/main/.github/CONTRIBUTING.md)?*

Fixes #

## Description

*Clearly and concisely describe the changes in this pull request.*

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would break existing functionality)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] CI/CD related changes
- [ ] Other (please describe):

## Checklist

- [ ] I have followed the project's coding style guidelines
- [ ] I have added tests that prove my fix/feature works
- [ ] All existing tests pass locally
- [ ] I have updated the documentation accordingly
- [ ] I have added appropriate type hints
- [ ] I have updated the CHANGELOG.md
- [ ] My changes generate no new warnings or errors
- [ ] I have checked my code with `black`, `isort`, and `mypy`