### PR TITLE
 [SECURITY] Update setuptools to >=78.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Security
+- Updated `setuptools` to `>=78.1.1` to address path traversal vulnerability (GHSA-r9hx-vwmv-q579) in deprecated `PackageIndex.download` function.
+
 ## [0.5.1] - 2025-11-28
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ requires-python = ">=3.9"
 dev = [
     "twine>=5.1.1",
     "matplotlib>=3.7.3,<3.8.0",
-    "setuptools>=70.0.0,<71.0.0",
+    "setuptools>=78.1.1",
     "pytest>=6.0.0,<8.0.0",
     "pytest-cov>=4.1.0",
     "sphinx>=6.0.0,<9.0.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 
 requests>=2.32.0,<2.33.0
 matplotlib>=3.7.3,<3.8.0
-setuptools>=70.0.0,<71.0.0
+setuptools>=78.1.1
 urllib3>=2.2.1,<3.0.0
 numpy~=1.26.4,<1.27.0
 scipy>=1.13.1,<1.15.0


### PR DESCRIPTION
  *Have you read the [Contributing Guidelines](https://github.com/PPeitsch/bcra-connector/blob/main/.github/CONTRIBUTING.md)?*

Fixes #52

## Description

Updated setuptools to address a critical path traversal vulnerability (GHSA-r9hx-vwmv-q579) in the deprecated PackageIndex.download function. This vulnerability could lead to arbitrary file write if a malicious package index is used.

**Vulnerability Details:**
- **CVE:** GHSA-r9hx-vwmv-q579
- **Severity:** High
- **Affected versions:** setuptools < 78.1.1
- **Fixed version:** setuptools >= 78.1.1

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Security fix

## Checklist

- [x] I have followed the project's coding style guidelines
- [x] All existing tests pass locally
- [x] I have updated the CHANGELOG.md
- [x] My changes generate no new warnings or errors