### PR TITLE
 [Feature]: Automate GitHub Release creation from CHANGELOG

### DIFF
--- a/.github/workflows/test-and-publish.yaml
+++ b/.github/workflows/test-and-publish.yaml
@@ -106,3 +106,33 @@ jobs:
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         # Trusted publishing via OIDC is configured by permissions and environment
+
+  release:
+    name: Create GitHub Release
+    needs: publish
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Get version from tag
+        id: tag_name
+        run: |
+          echo "current_version=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
+
+      - name: Read changelog
+        id: changelog
+        uses: mindsers/changelog-reader-action@v2
+        with:
+          version: ${{ steps.tag_name.outputs.current_version }}
+          path: ./CHANGELOG.md
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v1
+        with:
+          body: ${{ steps.changelog.outputs.changes }}
+          draft: false
+          prerelease: false


### PR DESCRIPTION
  *Have you read the [Contributing Guidelines](https://github.com/PPeitsch/bcra-connector/blob/main/.github/CONTRIBUTING.md)?*

Fixes #54

## Description

Added a new job \elease\ to the \	est-and-publish.yaml\ workflow. This job runs when a new tag starting with \*\ is pushed and the \publish\ job succeeds.

It performs the following:
1.  Extracts the version number from the tag.
2.  Uses \mindsers/changelog-reader-action\ to parse the \CHANGELOG.md\ and extract the notes for the corresponding version.
3.  Uses \softprops/action-gh-release\ to create a GitHub Release with the extracted notes as the body.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] CI/CD related changes

## Checklist

- [x] I have followed the project's coding style guidelines
- [x] All existing tests pass locally
- [x] I have updated the CHANGELOG.md (N/A - CI change)