### PR TITLE
docs: Fix documentation inconsistencies after API v4.0 update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -336,7 +336,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Installation guide
 
 
-[Unreleased]: https://github.com/PPeitsch/bcra-connector/compare/v0.6.2...HEAD
+[Unreleased]: https://github.com/PPeitsch/bcra-connector/compare/v0.7.0...HEAD
+[0.7.0]: https://github.com/PPeitsch/bcra-connector/compare/v0.6.2...v0.7.0
 [0.6.2]: https://github.com/PPeitsch/bcra-connector/compare/v0.6.1...v0.6.2
 [0.6.1]: https://github.com/PPeitsch/bcra-connector/compare/v0.6.0...v0.6.1
 [0.6.0]: https://github.com/PPeitsch/bcra-connector/compare/v0.5.4...v0.6.0

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -64,6 +64,18 @@ Testing
 * All integration tests validated against live v4.0 API
 * MyPy type checking passing without errors
 
+0.6.2 - 2025-12-08
+------------------
+
+Fixed
+^^^^^
+* Corrected package name from ``bcra-api-connector`` to ``bcra-connector`` in installation documentation (#73).
+* Added missing imports to code examples in ``usage.rst`` and ``configuration.rst`` so they can be copied and run directly.
+* Updated ``examples.rst`` to include import statements by changing ``:lines: 11-`` to ``:lines: 6-`` for all example files.
+* Fixed all example files to use ``from bcra_connector import`` instead of ``from src.bcra_connector import``.
+* Removed unnecessary ``sys.path`` manipulation from example files (users should use ``pip install -e .`` for development).
+* Cleaned up unused imports (``sys``) from example files while keeping necessary ones (``os`` for ``save_plot()``).
+
 0.6.1 - 2025-12-08
 ------------------
 

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -31,9 +31,9 @@ To retrieve all principal variables published by BCRA:
 
    variables = connector.get_principales_variables()
    for var in variables[:5]:  # Print first 5 for brevity
-       print(f"{var.descripcion}: {var.valor} ({var.fecha})")
+       print(f"{var.descripcion}: {var.ultValorInformado} ({var.ultFechaInformada})")
 
-This will return a list of `PrincipalesVariables` objects, each containing information about a specific variable.
+This will return a list of `PrincipalesVariables` objects, each containing information about a specific variable including metadata like `tipoSerie`, `periodicidad`, and `moneda`.
 
 Retrieving Historical Data
 --------------------------
@@ -45,11 +45,12 @@ To fetch historical data for a specific variable:
    id_variable = 1  # e.g., Reservas Internacionales del BCRA
    end_date = datetime.now()
    start_date = end_date - timedelta(days=30)
-   datos = connector.get_datos_variable(id_variable, start_date, end_date)
-   for dato in datos[-5:]:  # Print last 5 for brevity
-       print(f"{dato.fecha}: {dato.valor}")
+   response = connector.get_datos_variable(id_variable, desde=start_date, hasta=end_date)
+   for result in response.results:
+       for detalle in result.detalle[-5:]:  # Print last 5 for brevity
+           print(f"{detalle.fecha}: {detalle.valor}")
 
-This returns a list of `DatosVariable` objects, each representing a data point for the specified variable within the given date range.
+This returns a `DatosVariableResponse` object containing metadata and a list of `DatosVariable` results, each with a `detalle` list of `DetalleMonetaria` data points.
 
 Getting the Latest Value
 ------------------------


### PR DESCRIPTION
## Summary

Fixes documentation inconsistencies after the API v4.0 update (PR #75).

## Changes

- **usage.rst**: Updated examples to use v4.0 API structure
  - Use \ultValorInformado\/\ultFechaInformada\ instead of obsolete \alor\/\echa\
  - Updated \get_datos_variable()\ example for \DatosVariableResponse\ structure
- **changelog.rst**: Added missing 0.6.2 entry
- **CHANGELOG.md**: Fixed comparison links to include v0.7.0

Closes #76